### PR TITLE
Update project to be compatible with Hapi 8.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This generator creates a new [hapi](http://hapijs.com/) project with all the boilerplate you need to get started. The hapi-plugins selection in the prompt will be automatically added to the composer manifest.
 
+Updated to support Hapi 8.x
+
 ## Installation
 
 Install the generator by running: `npm install -g generator-hapi-composer`

--- a/app/index.js
+++ b/app/index.js
@@ -312,7 +312,7 @@ module.exports = yeoman.generators.Base.extend({
 
     if (this.hapiPlugins) {
       Object.keys(this.hapiPlugins).forEach(function(key) {
-        _composerConfig.plugins[key] = {};
+        _composerConfig.plugins[key] = ( key === 'yar' ? { "cookieOptions": { "password": "passwordToEncryptCookie" } } : {} );
       });
     }
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,8 @@
     "composer"
   ],
   "dependencies": {
-    "hapi": "6.x.x"<% if (dependencies) { %>,
+    "hapi": "~8.x.x",
+    "glue": "^2.1.0"<% if (dependencies) { %>,
 <%= dependencies %><% } %>
   },
   "devDependencies": {

--- a/app/templates/lib/_index.js
+++ b/app/templates/lib/_index.js
@@ -15,7 +15,8 @@
 // var fs = require('fs');
 //
 // // External libs
-var Hapi = require('hapi');
+var Hapi = require('hapi'),
+  Glue = require('glue');
 //
 // // Internal libs
 // var data = require('./data.js');
@@ -24,7 +25,7 @@ var Hapi = require('hapi');
 var config = require('./config.json');
 
 var manifest = {
-  servers: [{
+  connections: [{
     host: config.host,
     port: config.port
   }],
@@ -32,7 +33,7 @@ var manifest = {
 };
 
 if (!module.parent) {
-  Hapi.Pack.compose(manifest, function (err, pack) {
+  Glue.compose(manifest, function (err, pack) {
     if (err) {
       console.log('Failed composing');
     } else {

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -38,7 +38,7 @@ describe('generator-hapi-composer', function () {
       var expectedContent = [
         ['package.json', /"dependencies": {/],
         ['package.json', /"devDependencies": {/],
-        ['package.json', /"hapi": "6.x.x"/],
+        ['package.json', /"hapi": "^8.x.x"/],
         ['package.json', /"lab": "3.x.x"/],
         ['package.json', /"node": ">=0.10.22"/],
         ['package.json', /"gulp": "\^3.6.2"/],
@@ -537,7 +537,7 @@ describe('generator-hapi-composer', function () {
 
       var expectedContent = [
         ['package.json', /"yar"/],
-        ['lib/config.json', /"yar": {}/]
+        ['lib/config.json', /"yar": { "cookieOptions": { "password": "passwordToEncryptCookie" } }/]
       ];
 
       helpers.mockPrompt(this.app, {


### PR DESCRIPTION
The change at index.js:315 isn't ideal I think, but given the point of this generator, I think it's acceptable. Without it, the generated project will crash because no password is set on the jar cookie options.

I would encourage someone to veryify any tests because I only touched what was needed to get it running and serving the "don't worry, be hapi!" message so far. If I use this further and discover more issues, I will commit those.
